### PR TITLE
Add Instagram-to-Substack automation pipeline

### DIFF
--- a/instagram_to_substack/.env.example
+++ b/instagram_to_substack/.env.example
@@ -1,0 +1,23 @@
+# ── Instagram ────────────────────────────────────────────────────────────────
+# Your login credentials (needed for private profiles or to avoid rate limits)
+INSTAGRAM_USERNAME=your_instagram_username
+INSTAGRAM_PASSWORD=your_instagram_password
+
+# The profile to download posts from (usually your own username)
+TARGET_USERNAME=your_instagram_username
+
+# Where to save downloaded posts
+DOWNLOAD_DIR=./instagram_posts
+
+# ── Anthropic ─────────────────────────────────────────────────────────────────
+ANTHROPIC_API_KEY=sk-ant-...
+
+# ── Substack ──────────────────────────────────────────────────────────────────
+SUBSTACK_EMAIL=your@email.com
+SUBSTACK_PASSWORD=your_substack_password
+
+# Your publication URL, e.g. https://yourname.substack.com
+SUBSTACK_URL=https://yourname.substack.com
+
+# Tracks which posts have already been uploaded (prevents duplicates)
+PROCESSED_LOG=./processed_posts.json

--- a/instagram_to_substack/download_instagram.py
+++ b/instagram_to_substack/download_instagram.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Downloads Instagram posts (images + captions) using instaloader."""
+import os
+import sys
+import argparse
+from dotenv import load_dotenv
+import instaloader
+
+load_dotenv()
+
+
+def download_posts(username, password, target, output_dir, limit=None):
+    L = instaloader.Instaloader(
+        download_pictures=True,
+        download_videos=False,
+        download_video_thumbnails=True,
+        download_geotags=False,
+        download_comments=False,
+        save_metadata=True,
+        compress_json=False,
+        post_metadata_txt_pattern="{caption}",
+        dirname_pattern=os.path.join(output_dir, "{target}"),
+        filename_pattern="{date_utc}_UTC",
+    )
+
+    if username and password:
+        print(f"Logging in as @{username}...")
+        L.login(username, password)
+    else:
+        print("No credentials provided — downloading as anonymous (public profiles only).")
+
+    print(f"Fetching posts from @{target}...")
+    profile = instaloader.Profile.from_username(L.context, target)
+
+    count = 0
+    for post in profile.get_posts():
+        if limit and count >= limit:
+            break
+        preview = (post.caption or "")[:60].strip().replace("\n", " ")
+        print(f"  [{count + 1}] {post.date_local.strftime('%Y-%m-%d')} — {preview}...")
+        L.download_post(post, target=profile.username)
+        count += 1
+
+    print(f"\nDone. {count} posts saved to {output_dir}/{target}/")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download Instagram posts with captions")
+    parser.add_argument("--username", default=os.getenv("INSTAGRAM_USERNAME"), help="Your Instagram username")
+    parser.add_argument("--password", default=os.getenv("INSTAGRAM_PASSWORD"), help="Your Instagram password")
+    parser.add_argument("--target", default=os.getenv("TARGET_USERNAME"), help="Profile to download")
+    parser.add_argument("--output-dir", default=os.getenv("DOWNLOAD_DIR", "./instagram_posts"))
+    parser.add_argument("--limit", type=int, default=None, help="Max number of posts to download")
+    args = parser.parse_args()
+
+    if not args.target:
+        print("Error: no target username. Use --target or set TARGET_USERNAME in .env")
+        sys.exit(1)
+
+    download_posts(args.username, args.password, args.target, args.output_dir, args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/instagram_to_substack/process_and_upload.py
+++ b/instagram_to_substack/process_and_upload.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+Reads downloaded Instagram posts, extracts titles via Claude, and creates
+Substack drafts via Playwright browser automation.
+"""
+import os
+import json
+import glob
+import argparse
+import sys
+from pathlib import Path
+from dotenv import load_dotenv
+import anthropic
+from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeout
+
+load_dotenv()
+
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+SUBSTACK_EMAIL = os.getenv("SUBSTACK_EMAIL")
+SUBSTACK_PASSWORD = os.getenv("SUBSTACK_PASSWORD")
+SUBSTACK_URL = os.getenv("SUBSTACK_URL", "").rstrip("/")
+POSTS_DIR = os.getenv("DOWNLOAD_DIR", "./instagram_posts")
+PROCESSED_LOG = os.getenv("PROCESSED_LOG", "./processed_posts.json")
+
+
+# ── Persistence ──────────────────────────────────────────────────────────────
+
+def load_processed():
+    if os.path.exists(PROCESSED_LOG):
+        with open(PROCESSED_LOG) as f:
+            return set(json.load(f))
+    return set()
+
+
+def save_processed(processed):
+    with open(PROCESSED_LOG, "w") as f:
+        json.dump(sorted(processed), f, indent=2)
+
+
+# ── Post discovery ────────────────────────────────────────────────────────────
+
+def get_posts(posts_dir):
+    posts = []
+    for txt_file in sorted(glob.glob(f"{posts_dir}/**/*.txt", recursive=True)):
+        path = Path(txt_file)
+        # instaloader caption files always have a date-like stem (contains digits)
+        if not any(c.isdigit() for c in path.stem):
+            continue
+
+        with open(txt_file, encoding="utf-8") as f:
+            caption = f.read().strip()
+
+        if not caption:
+            continue
+
+        image = None
+        for ext in [".jpg", ".jpeg", ".png", ".webp"]:
+            candidate = path.with_suffix(ext)
+            if candidate.exists():
+                image = str(candidate)
+                break
+
+        posts.append({
+            "id": str(path),
+            "caption": caption,
+            "image": image,
+            "date": path.stem,
+        })
+
+    return posts
+
+
+# ── Claude title extraction ───────────────────────────────────────────────────
+
+def extract_title_and_body(caption):
+    client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
+
+    response = client.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=1024,
+        messages=[{
+            "role": "user",
+            "content": f"""You are formatting an Instagram caption as a Substack newsletter post.
+
+Rules:
+- If the caption's first line is clearly a title (short, punchy, self-contained), use it as-is
+- Otherwise write a compelling title from the content (5–10 words max)
+- Body: preserve the original voice, remove hashtags, clean up line breaks for readability
+- Do not add any text that wasn't in the original caption
+
+Caption:
+{caption}
+
+Respond with JSON only — no markdown fences:
+{{"title": "...", "body": "..."}}""",
+        }],
+    )
+
+    text = response.content[0].text.strip()
+    # Strip markdown code fences if the model wraps anyway
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        lines = caption.strip().split("\n")
+        return {"title": lines[0][:100], "body": "\n".join(lines[1:]).strip() or caption}
+
+
+# ── Substack automation ───────────────────────────────────────────────────────
+
+def login_substack(page):
+    print("Logging into Substack...")
+    page.goto("https://substack.com/sign-in")
+    page.wait_for_load_state("networkidle")
+
+    page.get_by_placeholder("Type your email...").fill(SUBSTACK_EMAIL)
+    page.get_by_role("button", name="Continue").click()
+
+    try:
+        pwd = page.get_by_placeholder("Type your password...")
+        pwd.wait_for(timeout=6000)
+        pwd.fill(SUBSTACK_PASSWORD)
+        page.get_by_role("button", name="Sign in").click()
+        page.wait_for_load_state("networkidle")
+        print("Logged in.")
+    except PlaywrightTimeout:
+        print(
+            "\nSubstack sent a magic link instead of showing a password prompt.\n"
+            "Click the link in your email, then press Enter here to continue..."
+        )
+        input()
+
+
+def create_draft(page, title, body):
+    page.goto(f"{SUBSTACK_URL}/publish/post")
+    page.wait_for_load_state("networkidle")
+
+    # Title — try placeholder first, fall back to contenteditable h1
+    try:
+        title_el = page.get_by_placeholder("Title").first
+        title_el.wait_for(timeout=8000)
+        title_el.click()
+        title_el.fill(title)
+    except PlaywrightTimeout:
+        page.locator("h1[contenteditable], [data-testid='post-title']").first.click()
+        page.keyboard.type(title)
+
+    # Move to body editor
+    page.keyboard.press("Tab")
+    page.wait_for_timeout(400)
+
+    # Type body paragraph by paragraph
+    for para in body.split("\n\n"):
+        para = para.strip()
+        if para:
+            page.keyboard.type(para)
+            page.keyboard.press("Enter")
+            page.keyboard.press("Enter")
+
+    # Allow Substack's autosave to fire
+    page.wait_for_timeout(3000)
+    print(f"  Draft saved: {title}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Process Instagram posts → Substack drafts")
+    parser.add_argument("--posts-dir", default=POSTS_DIR, help="Folder containing downloaded posts")
+    parser.add_argument("--limit", type=int, default=None, help="Max posts to process this run")
+    parser.add_argument("--dry-run", action="store_true", help="Extract titles but skip Substack upload")
+    parser.add_argument("--headless", action="store_true", help="Run browser headlessly (no window)")
+    parser.add_argument("--reprocess", action="store_true", help="Re-process already-uploaded posts")
+    args = parser.parse_args()
+
+    if not ANTHROPIC_API_KEY:
+        print("Error: ANTHROPIC_API_KEY not set in .env")
+        sys.exit(1)
+
+    if not args.dry_run and not all([SUBSTACK_EMAIL, SUBSTACK_PASSWORD, SUBSTACK_URL]):
+        print("Error: SUBSTACK_EMAIL, SUBSTACK_PASSWORD, and SUBSTACK_URL must all be set in .env")
+        sys.exit(1)
+
+    posts = get_posts(args.posts_dir)
+    processed = load_processed()
+
+    if not args.reprocess:
+        posts = [p for p in posts if p["id"] not in processed]
+
+    if args.limit:
+        posts = posts[: args.limit]
+
+    print(f"Found {len(posts)} post(s) to process\n")
+
+    if not posts:
+        print("Nothing to do. Run download_instagram.py first, or use --reprocess.")
+        return
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=args.headless)
+        page = browser.new_page()
+
+        if not args.dry_run:
+            login_substack(page)
+
+        for i, post in enumerate(posts, 1):
+            print(f"\n[{i}/{len(posts)}] {post['date']}")
+            print(f"  Caption: {post['caption'][:80].replace(chr(10), ' ')}...")
+
+            result = extract_title_and_body(post["caption"])
+            title = result.get("title", "Untitled")
+            body = result.get("body", post["caption"])
+
+            print(f"  Title:   {title}")
+
+            if args.dry_run:
+                print("  [DRY RUN] Skipping Substack upload.")
+            else:
+                create_draft(page, title, body)
+
+            processed.add(post["id"])
+            save_processed(processed)
+
+        browser.close()
+
+    print(f"\nDone. {len(posts)} post(s) processed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/instagram_to_substack/requirements.txt
+++ b/instagram_to_substack/requirements.txt
@@ -1,0 +1,4 @@
+instaloader>=4.10
+anthropic>=0.25.0
+playwright>=1.44.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary

- `download_instagram.py` — bulk-downloads all posts + full captions from an Instagram profile using `instaloader`
- `process_and_upload.py` — uses Claude to extract/generate a title from each caption, then creates Substack drafts via Playwright browser automation
- `.env.example` — template for all credentials (Instagram, Anthropic, Substack)
- `requirements.txt` — Python dependencies

## How to use

```bash
cd instagram_to_substack
cp .env.example .env   # fill in your credentials
pip install -r requirements.txt
playwright install chromium

# Step 1: download your posts
python download_instagram.py --limit 10   # test with 10 first

# Step 2: process + upload to Substack as drafts
python process_and_upload.py --dry-run    # preview titles without uploading
python process_and_upload.py              # create real drafts
```

## Test plan

- [ ] `download_instagram.py` creates a folder with `.jpg` + `.txt` caption files per post
- [ ] `process_and_upload.py --dry-run` extracts titles from captions without touching Substack
- [ ] Full run logs into Substack and creates a draft with extracted title + formatted body
- [ ] `processed_posts.json` is updated after each post so re-runs skip already-uploaded posts

https://claude.ai/code/session_01VFcG4eNe1G95rjWmxiWwBx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFcG4eNe1G95rjWmxiWwBx)_