### PR TITLE
Alaya vision note: bespoke site off Thinkific

### DIFF
--- a/alaya-vision.html
+++ b/alaya-vision.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Alaya — Vision for a Bespoke Home</title>
+<style>
+  :root {
+    --ink: #2b2622;
+    --ink-soft: #6c6359;
+    --paper: #f6f1ea;
+    --paper-2: #efe7db;
+    --card: #fffdf9;
+    --line: #e4d9c9;
+    --accent: #b07d4f;      /* warm clay */
+    --accent-deep: #8a5e36;
+    --sage: #7e8b6f;
+    --glow: #f3e6d2;
+    --shadow: 0 24px 60px -28px rgba(80, 58, 32, 0.45);
+    --radius: 22px;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html { scroll-behavior: smooth; }
+
+  body {
+    font-family: ui-serif, Georgia, "Times New Roman", serif;
+    color: var(--ink);
+    background:
+      radial-gradient(1200px 700px at 80% -10%, var(--glow), transparent 60%),
+      radial-gradient(900px 600px at -10% 20%, #fbf6ee, transparent 55%),
+      var(--paper);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 860px; margin: 0 auto; padding: 0 26px; }
+
+  /* ---------- Hero ---------- */
+  header.hero {
+    min-height: 92vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+  }
+  .eyebrow {
+    font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+    letter-spacing: 0.42em;
+    text-transform: uppercase;
+    font-size: 12px;
+    color: var(--accent-deep);
+    margin-bottom: 28px;
+    opacity: 0;
+    animation: rise 1s ease 0.1s forwards;
+  }
+  h1.title {
+    font-size: clamp(44px, 8vw, 92px);
+    line-height: 1.02;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    margin-bottom: 26px;
+    opacity: 0;
+    animation: rise 1.1s ease 0.25s forwards;
+  }
+  h1.title em { font-style: italic; color: var(--accent-deep); }
+  .lede {
+    font-size: clamp(18px, 2.4vw, 23px);
+    max-width: 620px;
+    color: var(--ink-soft);
+    opacity: 0;
+    animation: rise 1.1s ease 0.45s forwards;
+  }
+  .scroll-cue {
+    margin-top: 64px;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+    opacity: 0;
+    animation: rise 1.1s ease 0.7s forwards;
+  }
+  .scroll-cue::before {
+    content: "";
+    display: block;
+    width: 1px; height: 44px;
+    margin-bottom: 14px;
+    background: linear-gradient(var(--accent), transparent);
+  }
+
+  @keyframes rise {
+    from { opacity: 0; transform: translateY(18px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  /* ---------- Sections ---------- */
+  section { padding: 86px 0; }
+  .section-tag {
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.34em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 18px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .section-tag::before {
+    content: "";
+    width: 26px; height: 1px; background: var(--accent);
+  }
+  h2 {
+    font-size: clamp(30px, 5vw, 46px);
+    font-weight: 500;
+    letter-spacing: -0.015em;
+    line-height: 1.1;
+    margin-bottom: 22px;
+  }
+  h2 em { font-style: italic; color: var(--accent-deep); }
+  p.body { font-size: 19px; color: #4a423a; margin-bottom: 18px; }
+  p.body strong { color: var(--ink); font-weight: 600; }
+
+  .divider {
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--line), transparent);
+    margin: 0 auto;
+    max-width: 860px;
+  }
+
+  /* ---------- Cards ---------- */
+  .cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 18px;
+    margin-top: 36px;
+  }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 28px 26px;
+    box-shadow: var(--shadow);
+    transition: transform 0.4s cubic-bezier(.2,.8,.2,1), box-shadow 0.4s ease;
+  }
+  .card:hover { transform: translateY(-6px); box-shadow: 0 34px 70px -30px rgba(80,58,32,.5); }
+  .card .ico {
+    width: 44px; height: 44px;
+    border-radius: 14px;
+    display: grid; place-items: center;
+    background: linear-gradient(150deg, var(--glow), #fff);
+    border: 1px solid var(--line);
+    font-size: 22px;
+    margin-bottom: 16px;
+  }
+  .card h3 { font-size: 21px; font-weight: 600; margin-bottom: 8px; }
+  .card p { font-size: 16px; color: var(--ink-soft); }
+
+  /* ---------- Pull quote ---------- */
+  .pull {
+    background: linear-gradient(160deg, #fffaf2, var(--paper-2));
+    border: 1px solid var(--line);
+    border-radius: 30px;
+    padding: 60px 48px;
+    text-align: center;
+    box-shadow: var(--shadow);
+  }
+  .pull p {
+    font-size: clamp(24px, 4vw, 34px);
+    font-style: italic;
+    line-height: 1.3;
+    color: var(--ink);
+    max-width: 640px;
+    margin: 0 auto;
+  }
+  .pull .by {
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-style: normal;
+    font-size: 12px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-top: 26px;
+  }
+
+  /* ---------- WhatsApp / research ---------- */
+  .fact {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 18px;
+    padding: 22px 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .fact:last-child { border-bottom: none; }
+  .fact .k {
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 13px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent-deep);
+    font-weight: 600;
+    min-width: 130px;
+  }
+  .fact .v { font-size: 17px; color: #4a423a; }
+  .fact .v small { color: var(--ink-soft); display:block; margin-top:4px; font-size: 14px; }
+
+  /* ---------- Roadmap ---------- */
+  .phase {
+    display: grid;
+    grid-template-columns: 70px 1fr;
+    gap: 24px;
+    align-items: start;
+    padding: 26px 0;
+    border-top: 1px solid var(--line);
+  }
+  .phase .num {
+    font-size: 40px;
+    font-style: italic;
+    color: var(--accent);
+    line-height: 1;
+  }
+  .phase h3 { font-size: 22px; font-weight: 600; margin-bottom: 6px; }
+  .phase p { color: var(--ink-soft); font-size: 16px; }
+  .phase .tag {
+    display: inline-block;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--sage);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 3px 10px;
+    margin-top: 10px;
+  }
+
+  /* ---------- open question callout ---------- */
+  .note {
+    background: #fff;
+    border: 1px dashed var(--accent);
+    border-radius: 16px;
+    padding: 20px 24px;
+    margin-top: 26px;
+    font-size: 16px;
+    color: var(--ink-soft);
+  }
+  .note b { color: var(--accent-deep); font-family: ui-sans-serif, system-ui, sans-serif; font-size: 12px; letter-spacing: 0.14em; text-transform: uppercase; display:block; margin-bottom: 6px; }
+
+  /* ---------- Footer ---------- */
+  footer {
+    padding: 70px 0 90px;
+    text-align: center;
+    color: var(--ink-soft);
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 13px;
+    letter-spacing: 0.06em;
+  }
+  footer .mark {
+    font-family: ui-serif, Georgia, serif;
+    font-size: 26px;
+    letter-spacing: 0.3em;
+    color: var(--ink);
+    margin-bottom: 14px;
+  }
+
+  .stack { display:flex; flex-direction:column; gap: 12px; }
+  ul.clean { list-style: none; margin-top: 16px; }
+  ul.clean li {
+    padding: 10px 0 10px 26px;
+    position: relative;
+    font-size: 17px;
+    color: #4a423a;
+    border-bottom: 1px solid var(--line);
+  }
+  ul.clean li::before {
+    content: "✦";
+    position: absolute; left: 0;
+    color: var(--accent);
+  }
+  ul.clean li:last-child { border-bottom: none; }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow">Alaya · Vision Note</div>
+    <h1 class="title">A home of our own.<br /><em>Beautiful to enter, silky to use.</em></h1>
+    <p class="lede">The idea: leave Thinkific behind entirely and build a bespoke experience we fully own — payments, community, live sessions, and curriculum all living under one calm, considered roof.</p>
+    <div class="scroll-cue">Read the thinking</div>
+  </div>
+</header>
+
+<div class="divider"></div>
+
+<!-- 1. The realization -->
+<section>
+  <div class="wrap">
+    <div class="section-tag">The realization</div>
+    <h2>We don't need the platform. <em>We need the experience.</em></h2>
+    <p class="body">Right now Thinkific owns the container our work lives in — its checkout, its lesson player, its limits, its look. The realization: none of that is load-bearing anymore. We can move off Thinkific <strong>entirely</strong> and build something bespoke.</p>
+    <p class="body">Payments become <strong>Stripe Checkout</strong> — clean, trusted, and frankly not that hard to wire up. Everything else is ours to shape. The bar for how it should <em>feel</em>: the silkiness of the best modern products. Things should glide. Nothing should feel like a course platform from 2016.</p>
+    <div class="cards">
+      <div class="card">
+        <div class="ico">✦</div>
+        <h3>Own the experience</h3>
+        <p>Every pixel, every transition, every word — ours. No third-party chrome bleeding through.</p>
+      </div>
+      <div class="card">
+        <div class="ico">◇</div>
+        <h3>Stripe Checkout</h3>
+        <p>Sell courses and memberships directly. Trusted, beautiful, and far simpler than it sounds.</p>
+      </div>
+      <div class="card">
+        <div class="ico">❖</div>
+        <h3>One roof</h3>
+        <p>Curriculum, community, live Zooms, and payments — all in one place that feels like home.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- pull quote -->
+<section>
+  <div class="wrap">
+    <div class="pull">
+      <p>"It could just be so beautiful — something on the level of silkiness where using it feels like a small pleasure, almost open and effortless."</p>
+      <div class="by">The feeling we're chasing</div>
+    </div>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- 2. WhatsApp -->
+<section>
+  <div class="wrap">
+    <div class="section-tag">The new doorway · WhatsApp</div>
+    <h2>Meeting people where they <em>already are.</em></h2>
+    <p class="body">Owning the platform unlocks something Thinkific never could: a real line into WhatsApp. Either a <strong>bot inside WhatsApp</strong> or a proper <strong>API integration</strong> that ties messages back to the site — onboarding, reminders, nudges, community pulse.</p>
+    <p class="body">Here's how it actually works, so we go in clear-eyed:</p>
+
+    <div style="margin-top:8px">
+      <div class="fact">
+        <div class="k">The API</div>
+        <div class="v">It's the <strong>WhatsApp Cloud API</strong> from Meta (the old on-premise version was retired in 2025). You reach it directly through Meta, or via a provider like Twilio, 360dialog, or Wati that adds no-code tooling on top.<small>A provider (BSP) is the faster path — visual flows, templates, CRM hooks without much custom code.</small></div>
+      </div>
+      <div class="fact">
+        <div class="k">What's free</div>
+        <div class="v"><strong>Replies within a 24-hour window are free.</strong> When a member messages us, the whole back-and-forth for the next 24h costs nothing.</div>
+      </div>
+      <div class="fact">
+        <div class="k">What costs</div>
+        <div class="v">Business-<em>initiated</em> messages are billed per template message. Utility/reminder messages are cheap; marketing blasts are the priciest (still cents). Provider platform fees start around <strong>$30/mo</strong>.<small>For a ~50-person community this is genuinely small money — likely tens of dollars a month, not hundreds.</small></div>
+      </div>
+      <div class="fact">
+        <div class="k">The shape</div>
+        <div class="v">Best fit: a <strong>utility + service bot</strong>. Welcome new members, send Zoom reminders, answer FAQs, surface "your next lesson" — all triggered from our own backend.</div>
+      </div>
+    </div>
+
+    <div class="note">
+      <b>Open question to decide</b>
+      Bot-first (automated flows) or human-in-the-loop (a shared inbox the team replies from)? And: start with a provider like Wati for speed, or go straight to the Cloud API for full control? Leaning provider-first to prove value, then bring it in-house.
+    </div>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- 3. Zoom + everything lives here -->
+<section>
+  <div class="wrap">
+    <div class="section-tag">Live & together · Zoom</div>
+    <h2>The Zooms live <em>here</em>, not in an inbox.</h2>
+    <p class="body">No more hunting for a link in an email from three weeks ago. Live sessions are scheduled, joined, and (where it makes sense) replayed right on the site. The calendar, the room, the recording, the chat afterward — one continuous thread.</p>
+    <ul class="clean">
+      <li>Upcoming sessions surfaced on the member's home — one tap to join.</li>
+      <li>Recordings flow back into the curriculum automatically once a call ends.</li>
+      <li>WhatsApp sends the gentle "starting in 15 minutes" nudge.</li>
+      <li>Everything stitched together so a member never has to leave to participate.</li>
+    </ul>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- 4. Migration -->
+<section>
+  <div class="wrap">
+    <div class="section-tag">The move · Migration</div>
+    <h2>Bringing the work — and the people — <em>with us.</em></h2>
+    <p class="body">Two things to migrate carefully: <strong>the curriculum</strong> and <strong>the ~50 people</strong> already in the community. Neither should feel disruptive. Here's the lay of the land from Thinkific's side:</p>
+
+    <div class="cards">
+      <div class="card">
+        <div class="ico">📚</div>
+        <h3>The curriculum</h3>
+        <p>Thinkific exports a course as a <strong>.zip</strong> (content + student data) or a <strong>CSV</strong> (structure only). Lesson text, structure, and ordering come out cleanly.</p>
+      </div>
+      <div class="card">
+        <div class="ico">🎬</div>
+        <h3>The catch on video</h3>
+        <p>Videos/audio hosted <em>on</em> Thinkific aren't in the export — but it gives us <strong>direct links</strong> to download each file. So we pull them down and re-host them ourselves.</p>
+      </div>
+      <div class="card">
+        <div class="ico">👥</div>
+        <h3>The ~50 members</h3>
+        <p>Export the member list, recreate accounts on our side, and invite people in warmly. Stripe carries their billing forward; WhatsApp can carry the welcome.</p>
+      </div>
+    </div>
+
+    <div class="note">
+      <b>The migration shape</b>
+      1) Export each course (.zip + CSV). 2) Download every video via the provided links and re-host. 3) Rebuild the curriculum structure in our own player. 4) Import the 50 members, set up Stripe, and send a warm "we've moved home" invite — ideally over WhatsApp.
+    </div>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- 5. Roadmap -->
+<section>
+  <div class="wrap">
+    <div class="section-tag">How it could unfold</div>
+    <h2>A calm sequence, not a <em>big bang.</em></h2>
+
+    <div class="phase">
+      <div class="num">01</div>
+      <div>
+        <h3>The bespoke shell + Stripe</h3>
+        <p>Stand up the site we own. Wire Stripe Checkout for one offering end-to-end. Prove the feeling — silky, beautiful, fast.</p>
+        <span class="tag">Foundation</span>
+      </div>
+    </div>
+    <div class="phase">
+      <div class="num">02</div>
+      <div>
+        <h3>Curriculum migration</h3>
+        <p>Pull courses from Thinkific, re-host the videos, rebuild the lesson experience in our own player.</p>
+        <span class="tag">Content</span>
+      </div>
+    </div>
+    <div class="phase">
+      <div class="num">03</div>
+      <div>
+        <h3>Bring the 50 home</h3>
+        <p>Migrate members, move billing to Stripe, and send a warm invitation into the new space.</p>
+        <span class="tag">Community</span>
+      </div>
+    </div>
+    <div class="phase">
+      <div class="num">04</div>
+      <div>
+        <h3>Zoom, woven in</h3>
+        <p>Live sessions scheduled and joined on-site; recordings flow back into the curriculum.</p>
+        <span class="tag">Live</span>
+      </div>
+    </div>
+    <div class="phase">
+      <div class="num">05</div>
+      <div>
+        <h3>WhatsApp doorway</h3>
+        <p>Start with a provider for reminders + onboarding. Expand into a fuller bot as it earns its place.</p>
+        <span class="tag">Reach</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<footer>
+  <div class="wrap">
+    <div class="mark">ALAYA</div>
+    <p>Vision note · captured 15 June 2026 · a place of our own</p>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
A single, self-contained HTML page (`alaya-vision.html`) that turns the brain dump into something readable — a calm, "silky" vision note for the Alaya redesign.

## What it captures
- **Off Thinkific, fully bespoke** — own the whole experience; payments via **Stripe Checkout**.
- **WhatsApp** — researched: it's the **Cloud API** (direct or via a BSP like Twilio/360dialog/Wati). Replies in a 24h window are free; business-initiated template messages cost cents; provider fees ~$30/mo. For ~50 members this is small money. Open question framed: bot-first vs. human-in-the-loop, provider vs. direct.
- **Zoom, woven in** — live sessions joined and replayed on-site, not buried in email.
- **Migration** — Thinkific exports as `.zip`/CSV; **videos aren't included** but come with download links to re-host; plus a path for the ~50 community members.
- **Phased roadmap** — shell + Stripe → curriculum → members → Zoom → WhatsApp.

## Notes
- Your message cut off mid-sentence ("we have like fifty people in the communi…") — I assumed ~50 members. Tell me what got truncated and I'll fold it in.
- Pure HTML/CSS, no dependencies. Open `alaya-vision.html` in a browser to view.

https://claude.ai/code/session_01SrKtRsUYKoSCWpyEtbWR4B

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrKtRsUYKoSCWpyEtbWR4B)_