### PR TITLE
Mobile-first Knicks player guide (current roster + legends)

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+# Deploy only the standalone Knicks page — ignore the WordPress site files
+*
+!knicks/
+!knicks/**
+!vercel.json

--- a/knicks/index.html
+++ b/knicks/index.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1" />
+<meta name="theme-color" content="#1d428a" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<meta name="apple-mobile-web-app-title" content="Knicks Faces" />
+<meta name="description" content="Meet the New York Knicks — the current roster and the all-time legends, face by face." />
+<title>Knicks Faces — Meet the New York Knicks</title>
+<style>
+  :root{
+    --blue:#1d428a;        /* Knicks royal blue */
+    --blue-deep:#0e2148;
+    --orange:#f58426;      /* Knicks orange */
+    --silver:#bec0c2;
+    --ink:#0c1426;
+    --card:#ffffff;
+    --bg:#f1f3f7;
+    --muted:#6b7385;
+    --shadow:0 6px 20px rgba(14,33,72,.12);
+    --safe-top:env(safe-area-inset-top,0px);
+    --safe-bottom:env(safe-area-inset-bottom,0px);
+  }
+  *{box-sizing:border-box;-webkit-tap-highlight-color:transparent;}
+  html,body{margin:0;padding:0;}
+  body{
+    font-family:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    background:var(--bg);
+    color:var(--ink);
+    -webkit-font-smoothing:antialiased;
+    overflow-x:hidden;
+  }
+
+  /* ---------- Header ---------- */
+  header{
+    position:sticky;top:0;z-index:30;
+    background:linear-gradient(135deg,var(--blue) 0%,var(--blue-deep) 100%);
+    color:#fff;
+    padding:calc(var(--safe-top) + 16px) 18px 14px;
+    box-shadow:0 4px 18px rgba(14,33,72,.28);
+  }
+  .brand{display:flex;align-items:center;gap:12px;}
+  .ball{
+    width:38px;height:38px;border-radius:50%;flex:0 0 auto;
+    background:radial-gradient(circle at 32% 28%,#ff9d4d,var(--orange) 60%,#d96a14);
+    position:relative;box-shadow:0 2px 8px rgba(0,0,0,.3);
+  }
+  .ball::before,.ball::after{content:"";position:absolute;background:rgba(14,33,72,.55);}
+  .ball::before{top:0;bottom:0;left:50%;width:2px;transform:translateX(-50%);}
+  .ball::after{left:0;right:0;top:50%;height:2px;transform:translateY(-50%);}
+  .titles h1{font-size:20px;margin:0;letter-spacing:.3px;font-weight:800;}
+  .titles p{margin:1px 0 0;font-size:12px;color:var(--silver);font-weight:500;}
+
+  /* ---------- Segmented tabs ---------- */
+  .seg{
+    display:flex;gap:4px;margin-top:14px;
+    background:rgba(255,255,255,.14);
+    padding:4px;border-radius:12px;
+  }
+  .seg button{
+    flex:1;border:0;background:transparent;color:#dfe6f5;
+    font-size:14px;font-weight:700;padding:9px 6px;border-radius:9px;
+    cursor:pointer;transition:.18s;letter-spacing:.2px;
+  }
+  .seg button.active{background:#fff;color:var(--blue);box-shadow:0 2px 6px rgba(0,0,0,.18);}
+
+  /* ---------- Search ---------- */
+  .searchwrap{padding:12px 14px 4px;}
+  .search{
+    width:100%;border:0;border-radius:12px;padding:12px 14px 12px 38px;
+    font-size:15px;background:#fff;box-shadow:var(--shadow);color:var(--ink);
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%236b7385' stroke-width='2.2' stroke-linecap='round'%3E%3Ccircle cx='11' cy='11' r='7'/%3E%3Cline x1='21' y1='21' x2='16.5' y2='16.5'/%3E%3C/svg%3E");
+    background-repeat:no-repeat;background-position:13px center;
+  }
+  .search:focus{outline:2px solid var(--orange);}
+
+  .section-note{
+    padding:6px 16px 2px;color:var(--muted);font-size:12.5px;font-weight:600;
+  }
+
+  /* ---------- Grid of faces ---------- */
+  .grid{
+    display:grid;grid-template-columns:1fr 1fr;gap:12px;
+    padding:12px 14px calc(var(--safe-bottom) + 28px);
+  }
+  .card{
+    background:var(--card);border-radius:18px;overflow:hidden;
+    box-shadow:var(--shadow);cursor:pointer;
+    display:flex;flex-direction:column;
+    transition:transform .12s ease;
+    border:1px solid rgba(14,33,72,.05);
+  }
+  .card:active{transform:scale(.97);}
+  .facewrap{
+    position:relative;width:100%;aspect-ratio:1/1;
+    background:linear-gradient(160deg,#e9edf6,#dde3f0);
+    overflow:hidden;
+  }
+  .facewrap img{
+    width:100%;height:100%;object-fit:cover;object-position:top center;display:block;
+  }
+  .monogram{
+    width:100%;height:100%;display:flex;align-items:center;justify-content:center;
+    font-size:40px;font-weight:800;color:#fff;letter-spacing:1px;
+    background:linear-gradient(150deg,var(--blue),var(--blue-deep));
+  }
+  .monogram span{transform:translateY(-2px);}
+  .num{
+    position:absolute;top:8px;left:8px;
+    background:var(--orange);color:#fff;font-weight:800;font-size:12px;
+    padding:3px 8px;border-radius:20px;box-shadow:0 2px 6px rgba(0,0,0,.25);
+  }
+  .pos{
+    position:absolute;top:8px;right:8px;
+    background:rgba(14,33,72,.82);color:#fff;font-weight:700;font-size:11px;
+    padding:3px 8px;border-radius:20px;
+  }
+  .meta{padding:9px 11px 12px;}
+  .meta h3{margin:0;font-size:14.5px;font-weight:800;line-height:1.15;}
+  .meta .tag{margin:3px 0 0;font-size:11.5px;color:var(--orange);font-weight:700;}
+
+  .empty{padding:40px 20px;text-align:center;color:var(--muted);font-size:14px;}
+
+  /* ---------- Detail sheet ---------- */
+  .sheet-back{
+    position:fixed;inset:0;z-index:50;background:rgba(8,16,36,.55);
+    backdrop-filter:blur(3px);opacity:0;pointer-events:none;transition:.2s;
+  }
+  .sheet-back.open{opacity:1;pointer-events:auto;}
+  .sheet{
+    position:fixed;left:0;right:0;bottom:0;z-index:60;
+    background:#fff;border-radius:22px 22px 0 0;
+    transform:translateY(102%);transition:transform .28s cubic-bezier(.2,.8,.2,1);
+    max-height:92vh;overflow-y:auto;
+    padding-bottom:calc(var(--safe-bottom) + 24px);
+    box-shadow:0 -8px 40px rgba(0,0,0,.3);
+  }
+  .sheet.open{transform:translateY(0);}
+  .grab{width:42px;height:5px;border-radius:3px;background:#d3d8e3;margin:10px auto 4px;}
+  .hero{
+    position:relative;width:100%;aspect-ratio:1/1;max-height:60vh;overflow:hidden;
+    background:linear-gradient(160deg,#e9edf6,#dde3f0);
+  }
+  .hero img{width:100%;height:100%;object-fit:cover;object-position:top center;}
+  .hero .monogram{font-size:90px;}
+  .hero-grad{position:absolute;inset:0;background:linear-gradient(to top,rgba(14,33,72,.92),rgba(14,33,72,0) 55%);}
+  .hero-text{position:absolute;left:18px;right:18px;bottom:14px;color:#fff;}
+  .hero-text h2{margin:0;font-size:26px;font-weight:900;line-height:1.05;text-shadow:0 2px 10px rgba(0,0,0,.4);}
+  .pills{display:flex;gap:7px;flex-wrap:wrap;margin-top:8px;}
+  .pill{background:rgba(255,255,255,.92);color:var(--blue);font-weight:800;font-size:12px;padding:4px 10px;border-radius:20px;}
+  .pill.o{background:var(--orange);color:#fff;}
+  .bio{padding:16px 18px 4px;font-size:15px;line-height:1.5;color:#222b3d;}
+  .close{
+    position:absolute;top:10px;right:12px;z-index:5;
+    width:34px;height:34px;border-radius:50%;border:0;cursor:pointer;
+    background:rgba(14,33,72,.55);color:#fff;font-size:20px;line-height:34px;text-align:center;
+  }
+  footer{
+    text-align:center;color:var(--muted);font-size:11px;
+    padding:0 20px calc(var(--safe-bottom) + 18px);
+  }
+</style>
+</head>
+<body>
+<header>
+  <div class="brand">
+    <div class="ball" aria-hidden="true"></div>
+    <div class="titles">
+      <h1>Knicks Faces</h1>
+      <p>Meet New York — past &amp; present</p>
+    </div>
+  </div>
+  <div class="seg" role="tablist">
+    <button id="tab-current" class="active" onclick="setTab('current')">Current Roster</button>
+    <button id="tab-legends" onclick="setTab('legends')">Legends</button>
+  </div>
+</header>
+
+<div class="searchwrap">
+  <input class="search" id="search" type="search" placeholder="Search a player…" autocomplete="off" />
+</div>
+<div class="section-note" id="note"></div>
+
+<div class="grid" id="grid"></div>
+
+<footer>
+  Photos via the official NBA headshot library. An unofficial fan guide • Tap any face for the story.
+</footer>
+
+<!-- Detail sheet -->
+<div class="sheet-back" id="sheet-back" onclick="closeSheet()"></div>
+<div class="sheet" id="sheet" role="dialog" aria-modal="true">
+  <button class="close" onclick="closeSheet()" aria-label="Close">×</button>
+  <div class="grab"></div>
+  <div class="hero" id="hero"></div>
+  <div class="bio" id="bio"></div>
+</div>
+
+<script>
+/* id = NBA headshot person id when confidently known; null -> monogram avatar */
+const CURRENT = [
+  {n:"Jalen Brunson",      id:1628973, num:"11", pos:"PG", role:"Captain & franchise face", bio:"The undisputed leader and engine of the offense. An All-NBA guard whose fearless shot-making in the clutch turned the Knicks back into a contender. The face of the franchise."},
+  {n:"Karl-Anthony Towns", id:1626157, num:"32", pos:"C",  role:"All-Star big man", bio:"A skilled, floor-stretching All-Star center who can drain threes and bully the paint. A dominant rebounder and matchup nightmare alongside Brunson."},
+  {n:"OG Anunoby",         id:1628384, num:"8",  pos:"F",  role:"Elite wing defender", bio:"A switchable, lockdown perimeter defender who routinely draws the toughest assignment — then knocks down corner threes on the other end."},
+  {n:"Mikal Bridges",      id:1628969, num:"25", pos:"F",  role:"Two-way iron-man", bio:"A durable, do-everything wing famous for almost never missing a game. Defends multiple positions and provides steady three-point scoring."},
+  {n:"Josh Hart",          id:1628404, num:"3",  pos:"G/F",role:"Glue guy & rebounder", bio:"The ultimate hustle player — a guard who rebounds like a forward and is a constant triple-double threat. The heartbeat of the team's effort."},
+  {n:"Mitchell Robinson",  id:1629011, num:"23", pos:"C",  role:"Rim protector", bio:"A springy, shot-blocking center and elite lob finisher who anchors the defense and crashes the offensive glass."},
+  {n:"Miles McBride",      id:1630540, num:"2",  pos:"PG", role:"3-and-D spark", bio:"“Deuce” — a tenacious on-ball defender and reliable three-point shooter who brings instant energy off the bench."},
+  {n:"Jordan Clarkson",    id:203903,  num:"",   pos:"G",  role:"Instant offense", bio:"A former Sixth Man of the Year and microwave scorer who can heat up in a hurry and carry bench units."},
+  {n:"Guerschon Yabusele", id:1627823, num:"",   pos:"F",  role:"Stretch forward", bio:"The “Dancing Bear” — a bruising, skilled big who can space the floor, bang inside, and bring veteran toughness."},
+  {n:"Jose Alvarado",      id:1630631, num:"",   pos:"PG", role:"Pest defender", bio:"A relentless, ball-hawking guard who lives in the passing lanes and energizes crowds with his full-court pressure."},
+  {n:"Jeremy Sochan",      id:1631110, num:"",   pos:"F",  role:"Versatile defender", bio:"A young, switchable forward with positional size and defensive intensity, still rounding out his offensive game."},
+  {n:"Landry Shamet",      id:1629013, num:"",   pos:"G",  role:"Floor spacer", bio:"A knockdown perimeter shooter whose gravity opens driving lanes for the stars."},
+  {n:"Tyler Kolek",        id:null,    num:"",   pos:"PG", role:"Young playmaker", bio:"A crafty, pass-first point guard out of Marquette developing as a backup ball-handler."},
+  {n:"Pacome Dadiet",      id:null,    num:"",   pos:"F",  role:"Wing prospect", bio:"A young French wing with intriguing size and upside, taken in the first round to develop for the future."},
+  {n:"Ariel Hukporti",     id:null,    num:"",   pos:"C",  role:"Young rim protector", bio:"An athletic German center and shot-blocker adding depth to the frontcourt."},
+  {n:"Kevin McCullar Jr.", id:null,    num:"",   pos:"G/F",role:"Two-way wing", bio:"A defensive-minded young wing working to earn rotation minutes."},
+  {n:"Dillon Jones",       id:null,    num:"",   pos:"F",  role:"Forward depth", bio:"A versatile young forward and rebounder who adds depth to the wing rotation."},
+  {n:"Mohamed Diawara",    id:null,    num:"",   pos:"F",  role:"Draft project", bio:"A long, raw French forward and recent draft addition with a high developmental ceiling."},
+];
+
+const LEGENDS = [
+  {n:"Patrick Ewing",       id:121,  num:"33", pos:"C", role:"The greatest Knick", bio:"Hall of Fame center and the heart of the franchise for 15 seasons. An 11-time All-Star whose dominance carried the gritty 1990s teams to the brink of a title. His No. 33 hangs in the Garden rafters."},
+  {n:"Walt 'Clyde' Frazier",id:null, num:"10", pos:"PG",role:"2× champion", bio:"Cool, clutch, and impossibly stylish, Clyde led the Knicks to their only two championships (1970 & 1973). His 36-point, 19-assist Game 7 in 1970 is the stuff of legend. Jersey retired — and still the team's iconic broadcaster."},
+  {n:"Willis Reed",         id:null, num:"19", pos:"C", role:"The Captain", bio:"2× champion, 2× Finals MVP, and 1970 league MVP. His limping, courageous walk onto the floor for Game 7 of the 1970 Finals remains one of basketball's most inspiring moments. Jersey retired."},
+  {n:"Earl 'The Pearl' Monroe",id:null,num:"15",pos:"PG",role:"Hall of Fame showman", bio:"A dazzling, improvisational scorer whose spins and shimmies thrilled the Garden. Paired with Frazier in the famed backcourt that won the 1973 title. Jersey retired."},
+  {n:"Bernard King",        id:null, num:"30", pos:"F", role:"Scoring machine", bio:"One of the most explosive scorers the game has seen. The 1984-85 NBA scoring champion, King poured in points with a lightning-quick release during his electric Knicks peak."},
+  {n:"Dave DeBusschere",    id:null, num:"22", pos:"F", role:"Defensive anchor", bio:"The rugged defensive backbone of both championship teams. A Hall of Famer whose toughness defined the early-'70s Knicks. Jersey retired."},
+  {n:"Bill Bradley",        id:null, num:"24", pos:"F", role:"2× champion", bio:"Princeton-educated, selfless forward and key piece of the 1970 & 1973 title teams. Later a U.S. Senator from New Jersey. Jersey retired."},
+  {n:"Dick Barnett",        id:null, num:"12", pos:"G", role:"2× champion", bio:"Smooth-shooting guard with the signature “fall back, baby” jumper on both championship teams. Jersey retired."},
+  {n:"Carmelo Anthony",     id:2546, num:"7",  pos:"F", role:"Scoring icon", bio:"A bucket-getting superstar who lit up MSG nightly. The 2012-13 NBA scoring champion and one of the most prolific scorers in franchise history."},
+  {n:"Allan Houston",       id:165,  num:"20", pos:"G", role:"Clutch shooter", bio:"A silky-smooth scorer whose floating runner — “The Shot” — stunned the rival Heat in 1999 and launched an unlikely Finals run."},
+  {n:"Amar'e Stoudemire",   id:2405, num:"1",  pos:"F", role:"Revived the Garden", bio:"“STAT” brought the buzz back to MSG in 2010-11 with a thunderous stretch of scoring that reminded New York how to dream again."},
+  {n:"John Starks",         id:null, num:"3",  pos:"G", role:"Fan favorite", bio:"From undrafted bagger to All-Star, Starks embodied New York grit. “The Dunk” over the Bulls in 1993 is forever etched in Knicks lore."},
+  {n:"Charles Oakley",      id:null, num:"34", pos:"F", role:"The enforcer", bio:"The fearless muscle of the '90s teams who protected his stars and owned the glass. As tough as anyone to ever wear the jersey."},
+  {n:"Latrell Sprewell",    id:null, num:"8",  pos:"G/F",role:"'99 Finals spark", bio:"An electric, fearless scorer whose fire powered the eighth-seeded Knicks' Cinderella run to the 1999 NBA Finals."},
+];
+
+const grid = document.getElementById('grid');
+const note = document.getElementById('note');
+const search = document.getElementById('search');
+let tab = 'current';
+
+function headshot(id){ return "https://cdn.nba.com/headshots/nba/latest/1040x760/"+id+".png"; }
+function initials(name){
+  // drop nicknames in quotes, then take first + last initial
+  const real = name.replace(/'[^']*'/g,'').split(/\s+/).filter(Boolean);
+  const a = (real[0]||name)[0]||'';
+  const b = (real[real.length-1]||'')[0]||'';
+  return (a+b).toUpperCase();
+}
+function faceHTML(p, big){
+  if(p.id){
+    return '<img loading="lazy" src="'+headshot(p.id)+'" alt="'+p.n+'" '+
+      'onerror="this.onerror=null;this.outerHTML=\'<div class=&quot;monogram&quot;><span>'+initials(p.n)+'</span></div>\'">';
+  }
+  return '<div class="monogram"><span>'+initials(p.n)+'</span></div>';
+}
+
+function render(){
+  const list = tab==='current'?CURRENT:LEGENDS;
+  const q = search.value.trim().toLowerCase();
+  const filtered = list.filter(p=>p.n.toLowerCase().includes(q));
+  note.textContent = tab==='current'
+    ? CURRENT.length+' players on the active roster'
+    : 'All-time greats who built the legend';
+  if(!filtered.length){
+    grid.innerHTML = '<div class="empty" style="grid-column:1/-1">No player found for “'+search.value+'”.</div>';
+    return;
+  }
+  grid.innerHTML = filtered.map((p,i)=>{
+    const idx = list.indexOf(p);
+    return '<div class="card" onclick="openSheet('+(tab==="current"?0:1)+','+idx+')">'+
+      '<div class="facewrap">'+faceHTML(p)+
+        (p.num?'<div class="num">#'+p.num+'</div>':'')+
+        '<div class="pos">'+p.pos+'</div>'+
+      '</div>'+
+      '<div class="meta"><h3>'+p.n+'</h3><p class="tag">'+p.role+'</p></div>'+
+    '</div>';
+  }).join('');
+}
+
+function setTab(t){
+  tab=t;
+  document.getElementById('tab-current').classList.toggle('active',t==='current');
+  document.getElementById('tab-legends').classList.toggle('active',t==='legends');
+  search.value='';
+  window.scrollTo({top:0,behavior:'smooth'});
+  render();
+}
+
+const sheet = document.getElementById('sheet');
+const sheetBack = document.getElementById('sheet-back');
+const hero = document.getElementById('hero');
+const bio = document.getElementById('bio');
+
+function openSheet(which, idx){
+  const p = (which===0?CURRENT:LEGENDS)[idx];
+  const pills = [p.num?'#'+p.num:'', p.pos, p.role].filter(Boolean)
+    .map((t,i)=>'<span class="pill'+(i===0&&p.num?' o':'')+'">'+t+'</span>').join('');
+  hero.innerHTML = faceHTML(p,true)+
+    '<div class="hero-grad"></div>'+
+    '<div class="hero-text"><h2>'+p.n+'</h2><div class="pills">'+pills+'</div></div>';
+  bio.innerHTML = '<p>'+p.bio+'</p>';
+  sheetBack.classList.add('open');
+  sheet.classList.add('open');
+  document.body.style.overflow='hidden';
+}
+function closeSheet(){
+  sheetBack.classList.remove('open');
+  sheet.classList.remove('open');
+  document.body.style.overflow='';
+}
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSheet();});
+
+search.addEventListener('input',render);
+render();
+</script>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "cleanUrls": true,
+  "rewrites": [
+    { "source": "/", "destination": "/knicks/index.html" }
+  ]
+}


### PR DESCRIPTION
## What this is

A self-contained, **iPhone-optimized** page for learning about the New York Knicks **face by face** — exactly the "I want faces" experience requested.

Lives at **`/knicks/`** (file: `knicks/index.html`). No build step, no dependencies — pure HTML/CSS/JS in one file.

## What you get

- **Two tabs** via an iOS-style segmented control:
  - **Current Roster** — the active 2025-26 squad, led with the stars to focus on (Brunson, Towns, Anunoby, Bridges, Hart, Robinson…).
  - **Legends** — the all-time greats (Ewing, Frazier, Reed, Monroe, Bernard King, DeBusschere, Carmelo, Houston, Stoudemire, Starks, Oakley, Sprewell…).
- **A face for every player.** Photos come from the official NBA headshot library. If a photo can't be confirmed, the card shows a clean Knicks-blue **monogram** (initials) instead — so nothing ever appears as a broken image.
- **Tap any face** for a detail sheet with a big photo, position/number pills, and a short "who they are" story.
- **Search** to jump to anyone, plus Knicks blue/orange styling, safe-area (notch) support, and add-to-home-screen meta tags.

## Notes
- Player data is editorial (roster, roles, bios) and easy to tweak inline in the `CURRENT` / `LEGENDS` arrays at the top of the script.
- A handful of younger/fringe players and classic-era legends intentionally use the monogram fallback rather than risk showing a wrong face.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yakc751JuYRfMUSWm74GR7)_